### PR TITLE
Grammar change to Layouts

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -361,7 +361,7 @@
     _setupLabel() {
       this.$label = this.$el.find('label');
       if (this.$label.length) {
-        this.$label.setAttribute('for', this.$input.attr('id'));
+        this.$label[0].setAttribute('for', this.$input.attr('id'));
       }
     }
 


### PR DESCRIPTION
This fixes a TypeError in the _setupLabel() function by forcing `Chips.$label` to be a single element instead of an array. See issue #6124.

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
